### PR TITLE
アーキテクチャ設計の追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,62 @@
 
 このリポジトリでの作業時は、すべてのやりとりを日本語で行うこと。
 
+# アーキテクチャ設計
+
+## アーキテクチャパターン
+
+Clean Architecture + Riverpod + Repository Patternを採用する。
+
+### レイヤー構成
+
+- **Presentation Layer**: UI + Riverpod Provider
+- **Domain Layer**: ビジネスロジック + Entity
+- **Data Layer**: Repository実装 + Local Data Source
+
+## 技術選定
+
+### Core依存関係
+
+- `flutter_riverpod`: 状態管理
+- `just_audio`: 高精度音声再生（リアルタイム性重視）
+- `google_mobile_ads`: 広告表示
+
+### 開発支援
+
+- `freezed`: データクラス生成
+- `json_annotation`: JSON処理
+
+### プロジェクト構成
+
+```
+analysis_options.yaml
+melos.yaml
+pubspec.yaml
+packages/
+├──bass_app/
+│   ├── pubspec.yaml
+│   ├── android/
+│   ├── ios/
+│   ├── macos/
+│   ├── test/
+│   └── lib/
+│       └── main.dart
+├── core/
+│   ├── lib/
+│   ├── test/
+│   └── pubspec.yaml
+├── features/
+│   ├── metronome/
+│   └── chord_progression/
+```
+
+## 設計方針
+
+- 完全オフライン動作（広告表示以外）
+- リアルタイム音声処理を重視
+- シンプルなコード進行生成
+- マルチプラットフォーム対応
+
 # コミットメッセージ規則
 
 コミットメッセージは短く簡潔に記述すること。


### PR DESCRIPTION
## Summary
- melosを使ったモノレポ構成を設計
- Clean Architecture + Riverpodベースの設計
- ベースアプリと共通ライブラリの分離

## Changes
- アーキテクチャパターンとレイヤー構成を定義
- 技術選定（Riverpod、just_audio等）を記載
- モノレポ構成（bass_app、core、features）を設計

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)