### PR TITLE
クリック音再生エリアのUIコンポーネント実装

### DIFF
--- a/packages/ui/practice/lib/src/practice_screen.dart
+++ b/packages/ui/practice/lib/src/practice_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:practice/src/widgets/area/bpm_setting_area.dart';
 import 'package:practice/src/widgets/area/chord_area.dart';
+import 'package:practice/src/widgets/area/metronome_area.dart';
 
 class PracticeScreen extends HookConsumerWidget {
   const PracticeScreen({super.key});
@@ -11,6 +12,8 @@ class PracticeScreen extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final bpm = useState(120);
+    final isPlaying = useState(false);
+    final currentBeat = useState(1);
     final chords = List<Chord>.generate(10000, (index) {
       final root = Note.values[index % Note.values.length];
       final type = ChordType.values[index % ChordType.values.length];
@@ -23,6 +26,21 @@ class PracticeScreen extends HookConsumerWidget {
         children: [
           ChordArea(
             chords: chords,
+          ),
+          const SizedBox(height: 16),
+          MetronomeArea(
+            isPlaying: isPlaying.value,
+            currentBeat: currentBeat.value,
+            onPlayPressed: () {
+              isPlaying.value = !isPlaying.value;
+              if (isPlaying.value) {
+                // メトロノーム開始時の処理をここに追加可能
+                currentBeat.value = 1;
+              } else {
+                // メトロノーム停止時の処理をここに追加可能
+                currentBeat.value = 1;
+              }
+            },
           ),
           const SizedBox(height: 16),
           BpmSettingArea(

--- a/packages/ui/practice/lib/src/widgets/area/metronome_area.dart
+++ b/packages/ui/practice/lib/src/widgets/area/metronome_area.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:practice/src/widgets/components/beat_indicator.dart';
+import 'package:practice/src/widgets/components/metronome_play_button.dart';
+
+class MetronomeArea extends StatelessWidget {
+  const MetronomeArea({
+    required this.isPlaying,
+    required this.currentBeat,
+    required this.onPlayPressed,
+    super.key,
+  });
+
+  final bool isPlaying;
+  final int currentBeat;
+  final VoidCallback onPlayPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        BeatIndicator(currentBeat: currentBeat),
+        const SizedBox(height: 16),
+        MetronomePlayButton(
+          isPlaying: isPlaying,
+          onPressed: onPlayPressed,
+        ),
+      ],
+    );
+  }
+}

--- a/packages/ui/practice/lib/src/widgets/components/beat_indicator.dart
+++ b/packages/ui/practice/lib/src/widgets/components/beat_indicator.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class BeatIndicator extends StatelessWidget {
+  const BeatIndicator({
+    required this.currentBeat,
+    super.key,
+  });
+
+  final int currentBeat;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      currentBeat.toString(),
+      style: Theme.of(context).textTheme.displayLarge?.copyWith(
+        color: Theme.of(context).colorScheme.primary,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+}

--- a/packages/ui/practice/lib/src/widgets/components/metronome_play_button.dart
+++ b/packages/ui/practice/lib/src/widgets/components/metronome_play_button.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class MetronomePlayButton extends StatelessWidget {
+  const MetronomePlayButton({
+    required this.isPlaying,
+    required this.onPressed,
+    super.key,
+  });
+
+  final bool isPlaying;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton(
+      onPressed: onPressed,
+      style: OutlinedButton.styleFrom(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        backgroundColor: Theme.of(context).colorScheme.secondary,
+        padding: const EdgeInsets.all(16),
+      ),
+      child: Icon(
+        isPlaying ? Icons.stop : Icons.play_arrow,
+        color: Theme.of(context).colorScheme.onPrimary,
+        size: 32,
+      ),
+    );
+  }
+}

--- a/packages/ui/practice/test/src/widgets/area/metronome_area_test.dart
+++ b/packages/ui/practice/test/src/widgets/area/metronome_area_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:practice/src/widgets/area/metronome_area.dart';
+import 'package:practice/src/widgets/components/beat_indicator.dart';
+import 'package:practice/src/widgets/components/metronome_play_button.dart';
+
+import '../../../widget_test_utils.dart';
+
+void main() {
+  group('MetronomeArea', () {
+    testWidgets('BeatIndicatorとMetronomePlayButtonが表示される', (tester) async {
+      await tester.setupTargetWidget(
+        MetronomeArea(
+          isPlaying: false,
+          currentBeat: 1,
+          onPlayPressed: () {},
+        ),
+      );
+
+      expect(find.byType(BeatIndicator), findsOneWidget);
+      expect(find.byType(MetronomePlayButton), findsOneWidget);
+    });
+
+    testWidgets('現在の拍が正しくBeatIndicatorに渡される', (tester) async {
+      const currentBeat = 3;
+
+      await tester.setupTargetWidget(
+        MetronomeArea(
+          isPlaying: false,
+          currentBeat: currentBeat,
+          onPlayPressed: () {},
+        ),
+      );
+
+      final beatIndicator = tester.widget<BeatIndicator>(
+        find.byType(BeatIndicator),
+      );
+
+      expect(beatIndicator.currentBeat, equals(currentBeat));
+    });
+
+    testWidgets('再生状態が正しくMetronomePlayButtonに渡される', (tester) async {
+      await tester.setupTargetWidget(
+        MetronomeArea(
+          isPlaying: true,
+          currentBeat: 1,
+          onPlayPressed: () {},
+        ),
+      );
+
+      final playButton = tester.widget<MetronomePlayButton>(
+        find.byType(MetronomePlayButton),
+      );
+
+      expect(playButton.isPlaying, isTrue);
+    });
+
+    testWidgets('PlayButtonのコールバックが正しく動作する', (tester) async {
+      var wasPressed = false;
+
+      await tester.setupTargetWidget(
+        MetronomeArea(
+          isPlaying: false,
+          currentBeat: 1,
+          onPlayPressed: () {
+            wasPressed = true;
+          },
+        ),
+      );
+
+      await tester.tap(find.byType(MetronomePlayButton));
+      await tester.pump();
+
+      expect(wasPressed, isTrue);
+    });
+
+    testWidgets('異なる拍数でも正しく表示される', (tester) async {
+      const testBeats = [1, 2, 3, 4];
+
+      for (final beat in testBeats) {
+        await tester.setupTargetWidget(
+          MetronomeArea(
+            isPlaying: false,
+            currentBeat: beat,
+            onPlayPressed: () {},
+          ),
+        );
+
+        expect(find.text(beat.toString()), findsOneWidget);
+      }
+    });
+
+    testWidgets('停止時と再生時の状態が正しく反映される', (tester) async {
+      // 停止時のテスト
+      await tester.setupTargetWidget(
+        MetronomeArea(
+          isPlaying: false,
+          currentBeat: 1,
+          onPlayPressed: () {},
+        ),
+      );
+
+      final playButtonStopped = tester.widget<MetronomePlayButton>(
+        find.byType(MetronomePlayButton),
+      );
+      expect(playButtonStopped.isPlaying, isFalse);
+
+      // 再生時のテスト
+      await tester.setupTargetWidget(
+        MetronomeArea(
+          isPlaying: true,
+          currentBeat: 2,
+          onPlayPressed: () {},
+        ),
+      );
+
+      final playButtonPlaying = tester.widget<MetronomePlayButton>(
+        find.byType(MetronomePlayButton),
+      );
+      expect(playButtonPlaying.isPlaying, isTrue);
+    });
+  });
+}

--- a/packages/ui/practice/test/src/widgets/components/beat_indicator_test.dart
+++ b/packages/ui/practice/test/src/widgets/components/beat_indicator_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:practice/src/widgets/components/beat_indicator.dart';
+
+import '../../../widget_test_utils.dart';
+
+void main() {
+  group('BeatIndicator', () {
+    testWidgets('現在の拍が正しく表示される', (tester) async {
+      const currentBeat = 3;
+
+      await tester.setupTargetWidget(
+        const BeatIndicator(currentBeat: currentBeat),
+      );
+
+      expect(find.text('3'), findsOneWidget);
+    });
+
+    testWidgets('異なる拍数が正しく表示される', (tester) async {
+      const testCases = [1, 2, 3, 4];
+
+      for (final beat in testCases) {
+        await tester.setupTargetWidget(
+          BeatIndicator(currentBeat: beat),
+        );
+
+        expect(find.text(beat.toString()), findsOneWidget);
+      }
+    });
+
+    testWidgets('Textウィジェットが表示される', (tester) async {
+      await tester.setupTargetWidget(
+        const BeatIndicator(currentBeat: 1),
+      );
+
+      expect(find.byType(Text), findsOneWidget);
+    });
+
+    testWidgets('適切なスタイルが適用されている', (tester) async {
+      await tester.setupTargetWidget(
+        const BeatIndicator(currentBeat: 1),
+      );
+
+      final text = tester.widget<Text>(find.byType(Text));
+
+      expect(text.style?.color, isNotNull);
+      expect(text.style?.fontWeight, FontWeight.bold);
+    });
+
+    testWidgets('0の拍も正しく表示される', (tester) async {
+      await tester.setupTargetWidget(
+        const BeatIndicator(currentBeat: 0),
+      );
+
+      expect(find.text('0'), findsOneWidget);
+    });
+
+    testWidgets('大きな数値も正しく表示される', (tester) async {
+      await tester.setupTargetWidget(
+        const BeatIndicator(currentBeat: 999),
+      );
+
+      expect(find.text('999'), findsOneWidget);
+    });
+  });
+}

--- a/packages/ui/practice/test/src/widgets/components/metronome_play_button_test.dart
+++ b/packages/ui/practice/test/src/widgets/components/metronome_play_button_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:practice/src/widgets/components/metronome_play_button.dart';
+
+import '../../../widget_test_utils.dart';
+
+void main() {
+  group('MetronomePlayButton', () {
+    testWidgets('停止時に再生アイコンが表示される', (tester) async {
+      await tester.setupTargetWidget(
+        MetronomePlayButton(
+          isPlaying: false,
+          onPressed: () {},
+        ),
+      );
+
+      expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+      expect(find.byIcon(Icons.stop), findsNothing);
+    });
+
+    testWidgets('再生時に停止アイコンが表示される', (tester) async {
+      await tester.setupTargetWidget(
+        MetronomePlayButton(
+          isPlaying: true,
+          onPressed: () {},
+        ),
+      );
+
+      expect(find.byIcon(Icons.stop), findsOneWidget);
+      expect(find.byIcon(Icons.play_arrow), findsNothing);
+    });
+
+    testWidgets('ボタンが押下されるとコールバックが呼ばれる', (tester) async {
+      var isPressed = false;
+
+      await tester.setupTargetWidget(
+        MetronomePlayButton(
+          isPlaying: false,
+          onPressed: () {
+            isPressed = true;
+          },
+        ),
+      );
+
+      await tester.tap(find.byType(OutlinedButton));
+      await tester.pump();
+
+      expect(isPressed, isTrue);
+    });
+
+    testWidgets('OutlinedButtonが表示される', (tester) async {
+      await tester.setupTargetWidget(
+        MetronomePlayButton(
+          isPlaying: false,
+          onPressed: () {},
+        ),
+      );
+
+      expect(find.byType(OutlinedButton), findsOneWidget);
+    });
+
+    testWidgets('適切なスタイルが適用されている', (tester) async {
+      await tester.setupTargetWidget(
+        MetronomePlayButton(
+          isPlaying: false,
+          onPressed: () {},
+        ),
+      );
+
+      final button = tester.widget<OutlinedButton>(
+        find.byType(OutlinedButton),
+      );
+
+      expect(button.style?.backgroundColor, isNotNull);
+      expect(button.style?.shape, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **MetronomePlayButton**: 再生/停止切り替えボタンコンポーネント
- **BeatIndicator**: 現在の拍を表示するコンポーネント  
- **MetronomeArea**: メトロノーム操作エリア
- **PracticeScreen統合**: 動作確認のため大雑把にコンポーネントを配置

## 実装内容
- 既存の`BpmSettingArea`の構造を参考にしたUIパーツ
- `useState`によるシンプルな状態管理
- 既存デザインと統一されたスタイル

## Test plan
- [ ] MetronomePlayButtonの再生/停止アイコン切り替えが動作する
- [ ] BeatIndicatorで拍数が正しく表示される
- [ ] MetronomeAreaでボタン押下時の状態変更が動作する
- [ ] PracticeScreenでUIコンポーネントが表示される

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #38